### PR TITLE
Automatic tests registration for tests written in C

### DIFF
--- a/basic_testing.h
+++ b/basic_testing.h
@@ -746,22 +746,16 @@ static int bt_add_test(struct bt_test_descriptor * t) {
     return 1;
 }
 
-#ifdef __cplusplus
-#define TEST(test_name)							\
-BT_POSSIBLY_UNUSED static int test_name ## _test ();					\
+#define  TEST(test_name)					\
+BT_POSSIBLY_UNUSED static int test_name ## _test ();		\
 BT_POSSIBLY_UNUSED static struct bt_test_descriptor test_name ## _descr		\
     = { # test_name, test_name ## _test, __FILE__, __LINE__, 0};		\
 BT_POSSIBLY_UNUSED static struct bt_test_descriptor * test_name = & test_name ## _descr; \
-BT_POSSIBLY_UNUSED static const int test_name ## _init = bt_add_test(test_name);	\
+__attribute__((constructor)) static void test_name ## _register (void) { \
+    *bt_last_test_p = test_name;					\
+    bt_last_test_p = &(test_name->next);				\
+}									\
 BT_POSSIBLY_UNUSED static int test_name ## _test ()
-#else
-#define  TEST(test_name)						\
-BT_POSSIBLY_UNUSED static int test_name ## _test ();					\
-BT_POSSIBLY_UNUSED static struct bt_test_descriptor test_name ## _descr		\
-    = { # test_name, test_name ## _test, __FILE__, __LINE__, 0};		\
-BT_POSSIBLY_UNUSED static struct bt_test_descriptor * test_name = & test_name ## _descr; \
-BT_POSSIBLY_UNUSED static int test_name ## _test ()
-#endif
 
 BT_POSSIBLY_UNUSED static unsigned int bt_fail_count = 0;
 BT_POSSIBLY_UNUSED static unsigned int bt_pass_count = 0;
@@ -969,20 +963,10 @@ int bt_test_driver(int argc, char * argv[]) {
     return EXIT_ALL_TESTS_PASSED;
 }
 
-#ifdef __cplusplus
+
 #define MAIN_TEST_DRIVER(...)						\
     int main(int argc, char * argv[]) {					\
 	return bt_test_driver(argc, argv);				\
     }
-#else
-#define MAIN_TEST_DRIVER(...)						\
-    int main(int argc, char * argv[]) {					\
-	struct bt_test_descriptor * suite [] = { __VA_ARGS__ };		\
-	const unsigned n = sizeof(suite)/sizeof(struct bt_test_descriptor *); \
-	for (unsigned i = 0; i < n; ++i)				\
-	    bt_add_test(suite[i]);					\
-	return bt_test_driver(argc, argv);				\
-    }
-#endif
 
 #endif /* BASIC_TESTING_H_INCLUDED */

--- a/basic_testing.h
+++ b/basic_testing.h
@@ -963,7 +963,6 @@ int bt_test_driver(int argc, char * argv[]) {
     return EXIT_ALL_TESTS_PASSED;
 }
 
-
 #define MAIN_TEST_DRIVER(...)						\
     int main(int argc, char * argv[]) {					\
 	return bt_test_driver(argc, argv);				\

--- a/ex ws/example4 ws/tests/test1.c
+++ b/ex ws/example4 ws/tests/test1.c
@@ -46,10 +46,4 @@ TEST(same_prefix2) {
     TEST_PASSED;
 }
 
-MAIN_TEST_DRIVER(two_empty,
-		 first_empty,
-		 second_empty,
-		 one_char_equal,
-		 same_string,
-		 same_prefix1,
-		 same_prefix2)
+MAIN_TEST_DRIVER()

--- a/ex ws/example5 ws/tests/test1.c
+++ b/ex ws/example5 ws/tests/test1.c
@@ -46,10 +46,4 @@ TEST(same_prefix2) {
     TEST_PASSED;
 }
 
-MAIN_TEST_DRIVER(two_empty,
-		 first_empty,
-		 second_empty,
-		 one_char_equal,
-		 same_string,
-		 same_prefix1,
-		 same_prefix2)
+MAIN_TEST_DRIVER()

--- a/ex/example4/tests/test1.c
+++ b/ex/example4/tests/test1.c
@@ -46,10 +46,5 @@ TEST(same_prefix2) {
     TEST_PASSED;
 }
 
-MAIN_TEST_DRIVER(two_empty,
-		 first_empty,
-		 second_empty,
-		 one_char_equal,
-		 same_string,
-		 same_prefix1,
-		 same_prefix2)
+
+MAIN_TEST_DRIVER()

--- a/ex/example5/tests/test1.c
+++ b/ex/example5/tests/test1.c
@@ -46,10 +46,4 @@ TEST(same_prefix2) {
     TEST_PASSED;
 }
 
-MAIN_TEST_DRIVER(two_empty,
-		 first_empty,
-		 second_empty,
-		 one_char_equal,
-		 same_string,
-		 same_prefix1,
-		 same_prefix2)
+MAIN_TEST_DRIVER()

--- a/ex/memory_checks/tests/00_hash_map.c
+++ b/ex/memory_checks/tests/00_hash_map.c
@@ -268,16 +268,4 @@ TEST (map_insert_remove_series) {
 
 
 
-MAIN_TEST_DRIVER (compile,
-		 map_init,
-		 map_find_empty,
-		 map_insert,
-		 map_update,
-		 map_insert_collisions,
-		 map_update_collisions,
-		 map_free,
-		 map_remove,
-		 map_remove_not_found,
-		 map_remove_collisions,
-		 map_remove_collisions_not_found,
-		 map_insert_remove_series);
+MAIN_TEST_DRIVER ();

--- a/ex/memory_checks/tests/01_fail_allocations.c
+++ b/ex/memory_checks/tests/01_fail_allocations.c
@@ -395,24 +395,4 @@ TEST (fail_reallocarray_reset) {
 
 
 
-MAIN_TEST_DRIVER (compile,
-		 array_init,
-		 fail_malloc,
-		 reset_after_fail,
-		 fail_realloc_null,
-		 reset_after_fail_realloc_null,
-		 fail_realloc,
-		 reset_after_fail_realloc,
-		 fail_malloc_reset,
-		 fail_realloc_null_reset,
-		 fail_realloc_reset,
-		 array_init_calloc,
-		 fail_calloc,
-		 reset_after_fail_calloc,
-		 fail_reallocarray_null,
-		 reset_after_fail_reallocarray_null,
-		 fail_reallocarray,
-		 reset_after_fail_reallocarray,
-		 fail_calloc_reset,
-		 fail_reallocarray_null_reset,
-		 fail_reallocarray_reset);
+MAIN_TEST_DRIVER ();

--- a/ex/memory_checks/tests/01_fail_allocations_debug.c
+++ b/ex/memory_checks/tests/01_fail_allocations_debug.c
@@ -17,4 +17,4 @@ TEST (debugger) {
 
 
 
-MAIN_TEST_DRIVER (compile, debugger);
+MAIN_TEST_DRIVER ();

--- a/ex/memory_checks/tests/02_allocations_recording.c
+++ b/ex/memory_checks/tests/02_allocations_recording.c
@@ -136,13 +136,4 @@ TEST (reallocarray_map_update) {
 
 
 
-MAIN_TEST_DRIVER (compile,
-		 malloc_add_memory_table,
-		 malloc_fail,
-		 free_table_remove,
-		 realloc_map_insert,
-		 realloc_map_update,
-		 calloc_add_memory_table,
-		 calloc_fail,
-		 reallocarray_map_insert,
-		 reallocarray_map_update);
+MAIN_TEST_DRIVER ();

--- a/ex/memory_checks/tests/03_double_free.c
+++ b/ex/memory_checks/tests/03_double_free.c
@@ -17,4 +17,4 @@ TEST (invalid_free) {
 }
 
 
-MAIN_TEST_DRIVER (compile, invalid_free);
+MAIN_TEST_DRIVER ();

--- a/ex/memory_checks/tests/03_memory_leaks.c
+++ b/ex/memory_checks/tests/03_memory_leaks.c
@@ -19,4 +19,4 @@ TEST (memory_leak) {
 
 
 
-MAIN_TEST_DRIVER (compile, memory_leak);
+MAIN_TEST_DRIVER ();

--- a/ex/memory_checks/tests/03_memory_leaks_debug.c
+++ b/ex/memory_checks/tests/03_memory_leaks_debug.c
@@ -17,4 +17,4 @@ TEST (debugger) {
 
 
 
-MAIN_TEST_DRIVER (compile, debugger);
+MAIN_TEST_DRIVER ();

--- a/ex/memory_checks/tests/03_non_portable_malloc.c
+++ b/ex/memory_checks/tests/03_non_portable_malloc.c
@@ -16,4 +16,4 @@ TEST (malloc_zero_size) {
 
 
 
-MAIN_TEST_DRIVER (compile, malloc_zero_size);
+MAIN_TEST_DRIVER ();

--- a/ex/memory_checks/tests/03_non_portable_realloc.c
+++ b/ex/memory_checks/tests/03_non_portable_realloc.c
@@ -19,4 +19,4 @@ TEST (realloc_zero_size) {
 }
 
 
-MAIN_TEST_DRIVER (compile, realloc_zero_size);
+MAIN_TEST_DRIVER ();

--- a/ex/memory_checks/tests/04_budget_allocations.c
+++ b/ex/memory_checks/tests/04_budget_allocations.c
@@ -285,22 +285,4 @@ TEST (reallocarray_budget) {
 
 
 
-MAIN_TEST_DRIVER (compile,
-		 no_budget_set,
-		 zero_budget,
-		 reset_after_budget,
-		 simple_budget,
-		 free_increment_budget,
-		 free_increment_budget,
-		 budget_realloc_null,
-		 reset_after_budget_realloc_null,
-		 budget_realloc,
-		 reset_after_budget_realloc,
-		 malloc_budget_reset,
-		 realloc_null_budget_reset,
-		 realloc_budget_reset,
-		 set_higher_budget,
-		 set_lower_budget,
-		 zero_budget_calloc,
-		 simple_budget_calloc,
-		 reallocarray_budget);
+MAIN_TEST_DRIVER ();

--- a/ex/memory_checks/tests/04_budget_allocations_debug.c
+++ b/ex/memory_checks/tests/04_budget_allocations_debug.c
@@ -17,4 +17,4 @@ TEST (debugger) {
 
 
 
-MAIN_TEST_DRIVER (compile, debugger);
+MAIN_TEST_DRIVER ();

--- a/ex/memory_checks/tests/05_byte_budget_allocations.c
+++ b/ex/memory_checks/tests/05_byte_budget_allocations.c
@@ -303,22 +303,4 @@ TEST (reallocarray_budget) {
 
 
 
-MAIN_TEST_DRIVER (compile,
-		 no_budget_set,
-		 zero_budget,
-		 reset_after_budget,
-		 simple_budget,
-		 free_increment_budget,
-		 budget_realloc_null,
-		 reset_after_budget_realloc_null,
-		 budget_realloc,
-		 reset_after_budget_realloc,
-		 malloc_budget_reset,
-		 realloc_null_budget_reset,
-		 realloc_budget_reset,
-		 set_higher_budget,
-		 set_lower_budget,
-		 smaller_size_realloc,
-		 zero_budget_calloc,
-		 simple_budget_calloc,
-		 reallocarray_budget);
+MAIN_TEST_DRIVER ();

--- a/ex/memory_checks/tests/05_byte_budget_allocations_debug.c
+++ b/ex/memory_checks/tests/05_byte_budget_allocations_debug.c
@@ -17,4 +17,4 @@ TEST (debugger) {
 
 
 
-MAIN_TEST_DRIVER (compile, debugger);
+MAIN_TEST_DRIVER ();

--- a/ex/memory_checks/tests/06_scheduled_failures.c
+++ b/ex/memory_checks/tests/06_scheduled_failures.c
@@ -215,22 +215,4 @@ TEST (reallocarray_failure_reset) {
 
 
 
-MAIN_TEST_DRIVER (compile,
-		 fail_next_malloc_count,
-		 fail_next_malloc_size,
-		 malloc_no_failure,
-		 malloc_failure_reset,
-		 fail_next_realloc_count,
-		 fail_next_realloc_size,
-		 realloc_no_failure,
-		 realloc_failure_reset,
-		 setting_failure,
-		 reset_after_failure,
-		 fail_next_calloc_count,
-		 fail_next_calloc_size,
-		 calloc_no_failure,
-		 calloc_failure_reset,
-		 fail_next_reallocarray_count,
-		 fail_next_realloc_size,
-		 reallocarray_no_failure,
-		 reallocarray_failure_reset);
+MAIN_TEST_DRIVER ();

--- a/ex/memory_checks/tests/06_scheduled_failures_debug.c
+++ b/ex/memory_checks/tests/06_scheduled_failures_debug.c
@@ -17,4 +17,4 @@ TEST (debugger) {
 
 
 
-MAIN_TEST_DRIVER (compile, debugger);
+MAIN_TEST_DRIVER ();

--- a/ex/memory_checks/tests/07_calloc_reallocarray_failures.c
+++ b/ex/memory_checks/tests/07_calloc_reallocarray_failures.c
@@ -54,10 +54,4 @@ TEST (reallocarray_zero_size) {
 
 
 
-MAIN_TEST_DRIVER (compile,
-		  overflow_calloc,
-		  calloc_zero_nmemb,
-		  calloc_zero_size,
-		  overflow_reallocarray,
-		  reallocarray_zero_nmemb,
-		  reallocarray_zero_size);
+MAIN_TEST_DRIVER ();


### PR DESCRIPTION
Add registation of tests for test cases written in C. The registration by using the constructor compiler attribute.